### PR TITLE
request: add PID for ArduPilot.org

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -277,6 +277,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6136 | [https://github.com/TheiaSpace/ESATEPS Theia Space's ESAT Electrical Power Subsystem]
 0x1d50 | 0x6137 | [https://github.com/TheiaSpace/ESATADCS Theia Space's ESAT Attitude Determination and Control Subsystem]
 0x1d50 | 0x6138 | reserved for Theia Space's ESAT Communications Subsystem
+0x1d50 | 0x6135 | [https://github.com/ArduPilot/ardupilot/ ArduPilot autopilot]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
ArduPilot is a FOSS autopilot project, licensed under GPLv3+

We run on a wide variety of hardware, including a lot of OSHW compliant
hw. See https://github.com/ArduPilot/Schematics for some of the hw that
we run on (there are many other boards with schematics hosted by the
developers)

We are happy to use a single PID for all boards, with separation of
board types done using the USB descriptor strings by our bootloader