### PR TITLE
USB ID: add PID 0x613e and 0x613f for Geckonator bootloader

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -282,6 +282,8 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x613b | [https://github.com/MegabytePhreak/scope-footswitch scope-footswitch bootloader mode]
 0x1d50 | 0x613c | [https://github.com/MegabytePhreak/scope-footswitch scope-footswitch]
 0x1d50 | 0x613d | [https://github.com/nanusefue/crocopoi Crocopoi]
+0x1d50 | 0x613e | [https://github.com/flummer/geckoboot/ Geckonator Bootloader]
+0x1d50 | 0x613f | [https://github.com/flummer/geckoboot/ Geckonator Bootloader (target)]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
I would like to request two Product IDs for my Geckonator project, which is a small development board with a SiLabs Happy Gecko microcontroller.

The Product IDs are for the USB bootloader, that will show up as a mass storage device on the host computer.

Product ID 1 is for a bootloader that programs the device itself and Product ID 2 is for a bootloader that program a connected device.

The hardware is shared under CC-BY-SA and the firmware is GPLv3

Source files are shared at:
- https://github.com/flummer/geckonator-hw/
- https://github.com/flummer/geckonator-dev/
- https://github.com/flummer/geckoboot/

Descriptive string ID 1: "Geckonator Bootloader"
Descriptive string ID 2: "Geckonator Bootloader (target)"