### PR TITLE
request for USB IDs for various projects

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -288,6 +288,8 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6141 | [https://git.osmocom.org/osmo-ccid-firmware/ sysmocom sysmoOCTSIM]
 0x1d50 | 0x6142 | [https://git.osmocom.org/osmo-small-hardware/tree/clock-generator Osmocom clock generator]
 0x1d50 | 0x6143 | [https://git.osmocom.org/osmo-small-hardware/tree/clock-generator Osmocom clock generator (DFU)]
+0x1d50 | 0x6144 | [https://osmocom.org/projects/e1-t1-adapter/wiki/ICE40_E1_USB_interface Osmocom E1 adapter (DFU)]
+0x1d50 | 0x6145 | [https://osmocom.org/projects/e1-t1-adapter/wiki/ICE40_E1_USB_interface Osmocom E1 adapter]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]

--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -292,6 +292,8 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6145 | [https://osmocom.org/projects/e1-t1-adapter/wiki/ICE40_E1_USB_interface Osmocom E1 adapter]
 0x1d50 | 0x6146 | [https://github.com/smunaut/ice40-playground Generic iCE40 DFU bootloader]
 0x1d50 | 0x6147 | [https://github.com/smunaut/ice40-playground Generic iCE40 Demo App]
+0x1d50 | 0x6148 | iCEpick (DFU)
+0x1d50 | 0x6149 | iCEpick
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]

--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -290,6 +290,8 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6143 | [https://git.osmocom.org/osmo-small-hardware/tree/clock-generator Osmocom clock generator (DFU)]
 0x1d50 | 0x6144 | [https://osmocom.org/projects/e1-t1-adapter/wiki/ICE40_E1_USB_interface Osmocom E1 adapter (DFU)]
 0x1d50 | 0x6145 | [https://osmocom.org/projects/e1-t1-adapter/wiki/ICE40_E1_USB_interface Osmocom E1 adapter]
+0x1d50 | 0x6146 | [https://github.com/smunaut/ice40-playground Generic iCE40 DFU bootloader]
+0x1d50 | 0x6147 | [https://github.com/smunaut/ice40-playground Generic iCE40 Demo App]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]

--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -287,6 +287,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6140 | [https://git.osmocom.org/osmo-asf4-dfu/ osmo-ASF4-DFU SAM E5x/D5x USB DFU bootloader]
 0x1d50 | 0x6141 | [https://git.osmocom.org/osmo-ccid-firmware/ sysmocom sysmoOCTSIM]
 0x1d50 | 0x6142 | [https://git.osmocom.org/osmo-small-hardware/tree/clock-generator Osmocom clock generator]
+0x1d50 | 0x6143 | [https://git.osmocom.org/osmo-small-hardware/tree/clock-generator Osmocom clock generator (DFU)]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
Details are in the individual commits, but in summary :

* Clock Gen DFU mode : Although not existing yet, it will ne needed and I think it's a good idea to allocate it contiguously before assigning more IDs.

* E1 adapter IDs for both DFU and runtime  ( I was using a 0xe1e1 IDs so far, so existing hw will need to be updated, better do that soon before there is too many boards ). Software licenses are mix of ( BSD / LGPL / GPL )

* Generic iCE40 USB core IDs : Mostly a DFU ID that can be used with this bootloader on any board that doesn't need/want its own IDs (and just use string for customization). Also a generic runtime ID that can be used safely as the default ID for demo apps using this core. Software licenses are mix of ( BSD / LGPL / GPL )

* iCEpick DFU & Runtime ID:  No dedicated project website yet, but all currently existing code is in the linked repo ( Mixed BSD / LGPL-3 / GPL ) on the commit in branches and since I'd like to distribute some protos around, having the final IDs would be very useful to avoid painful updates in the future.