### PR TITLE
request for BitMagic Logic Analyzer series USB IDs

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -294,6 +294,11 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6147 | [https://github.com/smunaut/ice40-playground Generic iCE40 Demo App]
 0x1d50 | 0x6148 | [https://github.com/smunaut/ice40-playground iCEpick (DFU)]
 0x1d50 | 0x6149 | [https://github.com/smunaut/ice40-playground iCEpick]
+0x1d50 | 0x6150 | [https://github.com/esden/bitmagic BitMagic-Basic Logic Analyzer]
+0x1d50 | 0x6151 | [https://github.com/esden/bitmagic BitMagic-One Logic Analyzer]
+0x1d50 | 0x6152 | [https://github.com/esden/bitmagic BitMagic-Plus Logic Analyzer]
+0x1d50 | 0x6153 | [https://github.com/esden/bitmagic BitMagic-Pro Logic Analyzer]
+0x1d50 | 0x6154 | [https://github.com/esden/bitmagic BitMagic Bootloader]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
The BitMagic Logic Analyzer hardware series is a group of open source hardware logic analyzers designed for the use with open source frameworks like [Sigrok](http://sigrok.org/) or [Orbuculum](https://github.com/mubes/orbuculum).

We have finalized the BitMagic-Basic hardware and the BitMagic-One hardware is in progress. As we have plans for higher end and more powerful versions of the hardware that will include a bootloader we would like to allocate adjacent IDs for future use.

All hardware designs are released under Creative Commons CC-BY-SA 4.0 license. The firmware is currently not hosted as part of the device itself and is part of the logic analyzer framework. For example the [fx2lafw](https://sigrok.org/wiki/Fx2lafw). All future firmware and gateware we will be developing as part of the BitMagic project will be developed under GPL or BSD licenses and released as such.

Let me know if you have any additional questions.