### PR TITLE
Add PIDs for Hackaday Supercon 2019 badge

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -294,6 +294,8 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6147 | [https://github.com/smunaut/ice40-playground Generic iCE40 Demo App]
 0x1d50 | 0x6148 | [https://github.com/smunaut/ice40-playground iCEpick (DFU)]
 0x1d50 | 0x6149 | [https://github.com/smunaut/ice40-playground iCEpick]
+0x1d50 | 0x614a | [https://github.com/Spritetm/hadbadge2019_fpgasoc/ Hackaday Supercon 2019 badge]
+0x1d50 | 0x614b | [https://github.com/Spritetm/hadbadge2019_fpgasoc/ Hackaday Supercon 2019 badge bootloader]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
Can we have a PID for our Hackaday Supercon badge? It's an ECP5 FPGA-based badge, running a RiscV-based SoC.

We already have the software and gate-ware opensourced. Software is GPL3, gateware is BSD3. (Exceptions are some modules we use from others, but their licenses are compatible.)

Firmware and gateware repo is here: https://github.com/Spritetm/hadbadge2019_fpgasoc/

We would like to apply for 2 PIDs:
- Hackaday Supercon 2019 Badge
- Hackaday Supercon 2019 Badge Bootloader

One is used for the main badge (MSC+CDC-ACM), the other will be for the bootloader (DFU).