### PR TITLE
Add USB PIDs for fibrefly.io "hotaru" board

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -297,6 +297,10 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x614a | [https://github.com/Spritetm/hadbadge2019_fpgasoc/ Hackaday Supercon 2019 badge]
 0x1d50 | 0x614b | [https://github.com/Spritetm/hadbadge2019_fpgasoc/ Hackaday Supercon 2019 badge bootloader]
 0x1d50 | 0x614c | [https://github.com/dwtk/dwtk-ice/ dwtk In-Circuit Emulator]
+0x1d50 | 0x6158 | [https://github.com/fibrefly-io/hotaru fibrefly.io "hotaru" Type-C interface]
+0x1d50 | 0x6159 | [https://github.com/fibrefly-io/hotaru fibrefly.io "hotaru" Type-C interface DFU]
+0x1d50 | 0x615a | [https://github.com/fibrefly-io/hotaru fibrefly.io "hotaru" Dual JTAG/SWD and dual serial]
+0x1d50 | 0x615b | [https://github.com/fibrefly-io/hotaru fibrefly.io "hotaru" USB 2.0 hub]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
Project is released under Cern OHL v1.2 and available at
https://github.com/fibrefly-io/hotaru

Firmware for the STM32 doesn't exist yet, boards should be arriving in a
few weeks.

The USB hub doesn't *really* need its own PID.  The FT4232H *does* need
a PID because the configuration it is used in (2x JTAG) is uncommon, in
particular I'd like to submit a PR to the Linux kernel to get both A and
B ports on the PID disabled from usb-serial use (but still have ports C
and D work, so completely ignoring it doesn't work either.)

---

If you don't want to assign PIDs before firmware exists, feel free to just close this PR, I totally understand.  I started at 0x6158 since I didn't want to collide with PR #6 which uses 6150...6154.  Of course I can also change this as needed.