### PR TITLE
Request USB PID for Generic USB Display

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -297,6 +297,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x614a | [https://github.com/Spritetm/hadbadge2019_fpgasoc/ Hackaday Supercon 2019 badge]
 0x1d50 | 0x614b | [https://github.com/Spritetm/hadbadge2019_fpgasoc/ Hackaday Supercon 2019 badge bootloader]
 0x1d50 | 0x614c | [https://github.com/dwtk/dwtk-ice/ dwtk In-Circuit Emulator]
+0x1d50 | 0x614d | [https://github.com/notro/gud/wiki Generic USB Display]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
This project is about turning a Linux computer into a USB Display.

Host driver and gadget driver have been posted:
[PATCH v2 00/10] Generic USB Display driver
https://lore.kernel.org/dri-devel/20200509141619.32970-1-noralf@tronnes.org/

The url used in the pid entry is the wiki that will be listed in the Linux MAINTAINERS file.
The gadget driver is licensed under GPL-2.0.
