### PR TITLE
Request to add usb id for Klipper

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -298,6 +298,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x614b | [https://github.com/Spritetm/hadbadge2019_fpgasoc/ Hackaday Supercon 2019 badge bootloader]
 0x1d50 | 0x614c | [https://github.com/dwtk/dwtk-ice/ dwtk In-Circuit Emulator]
 0x1d50 | 0x614d | [https://github.com/notro/gud/wiki Generic USB Display]
+0x1d50 | 0x614e | [https://www.klipper3d.org/ Klipper 3d-Printer Firmware]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
Klipper is a 3d-printer firmware.  It runs on a variety of micro-controllers (eg, AVR, STM32, ATSAMD, SAM).

Klipper uses the GNU GPLv3 license.  The main website is at https://www.klipper3d.org/ and the code is available at https://github.com/KevinOConnor/klipper/ .