### PR TITLE
Request to add PID for CanoKey

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -304,3 +304,4 @@ Vendor ID | Product ID | Description
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]
+0x1d50 | 0xf1d0 | [https://github.com/canokeys/canokey-stm32 CanoKey]


### PR DESCRIPTION
CanoKey is an open-source security key, which supports OpenPGP Card, PIV (NIST SP 800-73-4), and FIDO2 (WebAuthn).

CanoKey uses the Apache 2.0 license. The main website is at https://www.canokeys.org/ and the code is available at https://github.com/canokeys/canokey-stm32.