### PR TITLE
Request to add PID for Logicbone DFU Bootloader

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -301,6 +301,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x614e | [https://www.klipper3d.org/ Klipper 3d-Printer Firmware]
 0x1d50 | 0x615b | [https://greatscottgadgets.com/luna/ LUNA USB Multitool]
 0x1d50 | 0x615c | [https://greatscottgadgets.com/luna/ Apollo FPGA Programmer]
+0x1d50 | 0x615d | [https://github.com/oskirby/logicbone/ Logicbone DFU Bootloader]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
This adds a USB PID for the DFU bootloader on the Logicbone FPGA
development board. The hardware for this project is licensed under
the CERN OHL v1.2 license and the hardware design files are hosted
at https://github.com/oskirby/logicbone

The bootloader project is a fork of the TinyFPGA bootloader,
licensed under the Apache 2.0 license. The Verilog sources are
hosted at https://github.com/oskirby/tinydfu-bootloader