### PR TITLE
Request: ZMK Firmware Project (mechanical keyboards)

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -307,6 +307,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x615b | [https://greatscottgadgets.com/luna/ LUNA USB Multitool]
 0x1d50 | 0x615c | [https://greatscottgadgets.com/luna/ Apollo FPGA Programmer]
 0x1d50 | 0x615d | [https://github.com/oskirby/logicbone/ Logicbone DFU Bootloader]
+0x1d50 | 0x615e | [https://zmkfirmware.dev ZMK Firmware]
 0x1d50 | 0x615f | [https://git.osmocom.org/osmo-ccid-firmware/tree/ccid_host osmo-ccid-firmware USB CCID gadget]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]


### PR DESCRIPTION
* Website: https://zmkfirmware.dev/
* License: MIT

We have been developing a new MIT licensed firmware for mechanical
keyboards based on the Zephyr RTOS. In particular, the goal is to
have a firmware with solid BLE support baked in.

We are targetting supporting a wide variety of hardware, using
the broad support the upstream Zephyr project has. Currently,
we support two "Pro-Micro Footprint Compatible" boards, and
several users have already gotten the firmware working using
Adafruit Feather boards.

In order to support a variety of PCBs that accept one of those
smaller daughter boards (of which support for others is planned),
we ideally will end up with:

<# of supported MCU boards > x < # of PCB daughter boards>

unique product IDs, which is why this request includes a range.