### PR TITLE
USB IDs for the Osmocom E1 tracer

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -299,6 +299,8 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x614c | [https://github.com/dwtk/dwtk-ice/ dwtk In-Circuit Emulator]
 0x1d50 | 0x614d | [https://github.com/notro/gud/wiki Generic USB Display]
 0x1d50 | 0x614e | [https://www.klipper3d.org/ Klipper 3d-Printer Firmware]
+0x1d50 | 0x6150 | [https://osmocom.org/projects/e1-t1-adapter/wiki/E1_tracer Osmocom E1 tracer (DFU)]
+0x1d50 | 0x6151 | [https://osmocom.org/projects/e1-t1-adapter/wiki/E1_tracer Osmocom E1 tracer]
 0x1d50 | 0x615b | [https://greatscottgadgets.com/luna/ LUNA USB Multitool]
 0x1d50 | 0x615c | [https://greatscottgadgets.com/luna/ Apollo FPGA Programmer]
 0x1d50 | 0x615d | [https://github.com/oskirby/logicbone/ Logicbone DFU Bootloader]


### PR DESCRIPTION
This was originally a "one-off" at CCC, but is getting a dedicated board
with everything integrated on it.

The wiki page is just a stub for now, but still has links to the published
hardware (eagle) along with the original prototype version page that has
the published fpga gateware / firmware and host software.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>