### PR TITLE
usb_product_ids: Update name/link for the ice40 bootloader

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -292,7 +292,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6143 | [https://git.osmocom.org/osmo-small-hardware/tree/clock-generator Osmocom clock generator (DFU)]
 0x1d50 | 0x6144 | [https://osmocom.org/projects/e1-t1-adapter/wiki/ICE40_E1_USB_interface Osmocom E1 adapter (DFU)]
 0x1d50 | 0x6145 | [https://osmocom.org/projects/e1-t1-adapter/wiki/ICE40_E1_USB_interface Osmocom E1 adapter]
-0x1d50 | 0x6146 | [https://github.com/smunaut/ice40-playground Generic iCE40 DFU bootloader]
+0x1d50 | 0x6146 | [https://github.com/no2fpga/no2bootloader Nitro FGPA bootloader]
 0x1d50 | 0x6147 | [https://github.com/smunaut/ice40-playground Generic iCE40 Demo App]
 0x1d50 | 0x6148 | [https://github.com/smunaut/ice40-playground iCEpick (DFU)]
 0x1d50 | 0x6149 | [https://github.com/smunaut/ice40-playground iCEpick]


### PR DESCRIPTION
Project has been split off into its own repo and renamed.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>