### PR TITLE
Request for Adding BlueMicro nRF52 Bootloader & Firmware

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -309,6 +309,8 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x615d | [https://github.com/oskirby/logicbone/ Logicbone DFU Bootloader]
 0x1d50 | 0x615e | [https://zmkfirmware.dev ZMK Firmware]
 0x1d50 | 0x615f | [https://git.osmocom.org/osmo-ccid-firmware/tree/ccid_host osmo-ccid-firmware USB CCID gadget]
+0x1d50 | 0x6160 | [https://github.com/jpconstantineau/BlueMicro_BLE BlueMicro nRF52 Keyboard Bootloader]
+0x1d50 | 0x6161 | [https://github.com/jpconstantineau/BlueMicro_BLE BlueMicro nRF52 Keyboard Firmware]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
Software Request for PID:
- License: BSD 3-Clause License
- Complete text of license is in LICENSE file
- File headers have copyright notice, including author(s) and date

Requesting 2 PIDs:
- First one is for the bootloader; which is also open sourced at https://github.com/adafruit/Adafruit_nRF52_Bootloader and requires a unique PID for any new boards.  I can make a separate request if needed but I won't have control on any of their main source files. (only the added board files; which is where a unique PID is needed)  The firmware (below) requires this bootloader.
- Second one is for the firmware itself. BlueMicro_BLE is a Bluetooth keyboard firmware that uses the Adafruit nRF52 Arduino Board Support Package and the Arduino tooling and libraries to make it simple to program a wireless keyboard.  The firmware is located here: https://github.com/jpconstantineau/BlueMicro_BLE, specifically in the "firmware" folder.

This firmware will run on multiple open source hardware projects. See https://github.com/jpconstantineau/NRF52-Board and https://github.com/joric/nrfmicro as examples of potential hardware targets of this software.

Please consider this PR. I am open for any improvements to the documentation and source files to make it easier to understand the licenses. 