### PR TITLE
Request PIDs for U96-SVM

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -254,6 +254,8 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x60f6 | [https://github.com/Blinkinlabs/EightByEight EightByEight Blinky Badge]
 0x1d50 | 0x60f7 | [http://cgit.jvnv.net/cardio/ cardio NFC/RFID card reader (bootloader)]
 0x1d50 | 0x60f8 | [http://cgit.jvnv.net/cardio/ cardio NFC/RFID card reader]
+0x1d50 | 0x60f9 | [https://github.com/sdoira/U96-SVM U96-SVM Stereo Vision Front-end 2.0]
+0x1d50 | 0x60fa | [https://github.com/sdoira/U96-SVM U96-SVM Stereo Vision Front-end 3.0]
 0x1d50 | 0x60fc | [https://www.cryptotrust.net/products.html OnlyKey Two-factor Authentication & Password Solution]
 0x1d50 | 0x6100 | [https://github.com/hbekel/overlay64 overlay64 video overlay module]
 0x1d50 | 0x6104 | [http://www.scopefun.com/ ScopeFun open source instrumentation]


### PR DESCRIPTION
[Description]

U96-SVM is an add-on board for Avnet Ultra96v2 to realize a stereo vision system based on Xilinx SoC.
This project contains both hardware and software design files.
We need USB PIDs because a sample application contained in this project offers a USB interface (USB2.0 and USB3.0) to the host PC.


[License]

	Hardware: TAPR
	Software: MIT


[Project URL]

	https://github.com/sdoira/U96-SVM


[VID/PID]

	0x1d50 / 0x60f9: U96-SVM Stereo Vision Front-end 2.0
	0x1d50 / 0x60fa: U96-SVM Stereo Vision Front-end 3.0
