### PR TITLE
Request PID for Splitty Ergonomic Keyboard

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -321,6 +321,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6167 | [https://github.com/TMaxElectronics/MidiStick_Firmware MIDI Compatible tesla coil interrupter]
 0x1d50 | 0x6168 | [https://github.com/TMaxElectronics/MidiStick_Firmware MIDI Compatible tesla coil interrupter]
 0x1d50 | 0x6169 | [https://github.com/TMaxElectronics/MidiStick_Firmware MIDI Compatible tesla coil interrupter]
+0x1d50 | 0x616b | [https://git.ni.fr.eu.org/splitty.git/about/ Splitty Ergonomic Keyboard]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
This is a split ergonomic keyboard based on the Ergodox layout without
the thumb cluster. It uses 32 keys per sides with Cherry MX compatibles
switches, thirty 1u and two vertical 1.5u caps.

The full design use the MIT license.

Project web site and source: https://git.ni.fr.eu.org/splitty.git/about/

Using QMK for software: https://github.com/qmk/qmk_firmware