### PR TITLE
Request OUIs for ISA 8-Bit Ethernet controller

### DIFF
--- a/ieee_oui.psv
+++ b/ieee_oui.psv
@@ -13,4 +13,4 @@ First identifier | Last identifier | Date | Purpose
 02-29-00 | 02-38-ff | 2014-02-10 | [http://www.kosagi.com/w/index.php?title=Novena_Main_Page Novena ARM Netbook]
 02-39-00 | 02-39-ff | 2014-01-28 | [https://ieee1394.wiki.kernel.org/index.php/Main_Page Linux Kernel FireWire (IEEE-1394) implementation]
 02-3a-00 | 02-59-ff | 2015-08-10 | [https://github.com/tessel/project Tessel 2 IoT and robotics development platform]
-02-60-00 | 02-7f-ff | 2015-08-10 | [https://github.com/skiselev/isa8_eth ISA 8-Bit Ethernet controller]
+02-60-00 | 02-7f-ff | 2021-05-22 | [https://github.com/skiselev/isa8_eth ISA 8-Bit Ethernet controller]

--- a/ieee_oui.psv
+++ b/ieee_oui.psv
@@ -13,3 +13,4 @@ First identifier | Last identifier | Date | Purpose
 02-29-00 | 02-38-ff | 2014-02-10 | [http://www.kosagi.com/w/index.php?title=Novena_Main_Page Novena ARM Netbook]
 02-39-00 | 02-39-ff | 2014-01-28 | [https://ieee1394.wiki.kernel.org/index.php/Main_Page Linux Kernel FireWire (IEEE-1394) implementation]
 02-3a-00 | 02-59-ff | 2015-08-10 | [https://github.com/tessel/project Tessel 2 IoT and robotics development platform]
+02-60-00 | 02-7f-ff | 2015-08-10 | [https://github.com/skiselev/isa8_eth ISA 8-Bit Ethernet controller]


### PR DESCRIPTION
Please allocate requested OUI range for my open source ISA 8-Bit Ethernet controller
**Name:** ISA 8-Bit Ethernet controller
**Description:** ISA 8-Bit Ethernet Controller is an open source network interface controller (NIC) card, designed specifically to be used in computers with 8-bit only ISA (aka XT) bus, such as IBM* PC, IBM* PC XT, various PC/XT compatibles, for example [Micro 8088](https://github.com/skiselev/micro_8088) system. It is based on Realtek RTL8019 ethernet controller and is NE2000-compatible.
**License:** The hardware design itself, including schematic and PCB layout design files are licensed under the strongly-reciprocal variant of CERN Open Hardware Licence version 2. The packet driver is licensed under GPLv2. The documentation is licensed under Creative Commons Attribution-ShareAlike 4.0 International License
**Project website:** [https://github.com/skiselev/isa8_eth](https://github.com/skiselev/isa8_eth)
