### PR TITLE
added nRF52840 BBoard

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -306,6 +306,8 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x614f | [https://github.com/Shik-Tech/N32B N32B midi controller]
 0x1d50 | 0x6150 | [https://osmocom.org/projects/e1-t1-adapter/wiki/E1_tracer Osmocom E1 tracer (DFU)]
 0x1d50 | 0x6151 | [https://osmocom.org/projects/e1-t1-adapter/wiki/E1_tracer Osmocom E1 tracer]
+0x1d50 | 0x6157 | [https://github.com/ddB0515/nRF52840-BBoard nRF52840-BBoard Bootloader]
+0x1d50 | 0x6158 | [https://github.com/ddB0515/nRF52840-BBoard nRF52840-BBoard Firmware]
 0x1d50 | 0x6159 | [https://github.com/no2fpga/no2muacm Nitro FPGA μACM]
 0x1d50 | 0x615a | [https://github.com/esden/icekeeb iCEKeeb keyboard]
 0x1d50 | 0x615b | [https://greatscottgadgets.com/luna/ LUNA USB Multitool]


### PR DESCRIPTION
Software Request for PID:

License: MIT License 
Complete text of license is in LICENSE file
File headers have copyright notice, including author(s) and date
Requesting 2 PIDs for https://github.com/ddB0515/nRF52840-BBoard

First one is for the bootloader; which is also open sourced at https://github.com/adafruit/Adafruit_nRF52_Bootloader and requires a unique PID for any new boards.
Already making changes to submit PR to be merged but can't without PID
Changes for bootloader are here (https://github.com/ddB0515/Adafruit_nRF52_Bootloader/tree/nrf52840-bboard)

Second one is for the firmware itself. nRF52840 BBoard is a breakout board that uses the https://github.com/jpconstantineau/Community_nRF52_Arduino and the Arduino tooling and libraries to make it simple to program. It can be program to do different things from HID keyboard, BLE trackers, etc. 

As this is 1st time I'm doing something like this if there is anything that needs to be fixed or changed let me know.
Thanks for support