### PR TITLE
USB Vendor and Product ID request for open HW project

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -306,6 +306,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x614f | [https://github.com/Shik-Tech/N32B N32B midi controller]
 0x1d50 | 0x6150 | [https://osmocom.org/projects/e1-t1-adapter/wiki/E1_tracer Osmocom E1 tracer (DFU)]
 0x1d50 | 0x6151 | [https://osmocom.org/projects/e1-t1-adapter/wiki/E1_tracer Osmocom E1 tracer]
+0x1d50 | 0x6155 | [https://bitbucket.org/lukaso25/udac-cs43198 uDAC stereo audio DA converter UAC1 24/96]
 0x1d50 | 0x6156 | [https://github.com/daglem/reDIP-SID reDIP SID (DFU)]
 0x1d50 | 0x6157 | [https://github.com/ddB0515/nRF52840-BBoard nRF52840-BBoard Bootloader]
 0x1d50 | 0x6158 | [https://github.com/ddB0515/nRF52840-BBoard nRF52840-BBoard Firmware]


### PR DESCRIPTION
Dear Open Moko team,

I would like to ask you for the USB Vendor and Product ID for my open HW project.

My USB device called "uDAC stereo audio DA converter UAC1 24/96" is a high quality stereo asynchronous USB audio digital to analog converter with 3.5 mm TRS jack output based on STM32F0 and CS43198.

This open hardware design is licensed under CERN Open Hardware License Version 2 - Weakly Reciprocal.

Link to the repository is https://bitbucket.org/lukaso25/udac-cs43198 .

The string description is "uDAC stereo audio DA converter UAC1 24/96" (slash can be omitted).

Selected VID and PID 0x1d50  0x616f.

Thank you.

Best regards

Lukáš Otava 