### PR TITLE
USB PID Request: Hardware project - EncoderPad_RP2040: a Video Editing Macropad!

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -306,6 +306,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x614f | [https://github.com/Shik-Tech/N32B N32B midi controller]
 0x1d50 | 0x6150 | [https://osmocom.org/projects/e1-t1-adapter/wiki/E1_tracer Osmocom E1 tracer (DFU)]
 0x1d50 | 0x6151 | [https://osmocom.org/projects/e1-t1-adapter/wiki/E1_tracer Osmocom E1 tracer]
+0x1d50 | 0x6154 | [https://github.com/jpconstantineau/EncoderPad_RP2040/ EncoderPad RP2040 Firmware]
 0x1d50 | 0x6155 | [https://bitbucket.org/lukaso25/udac-cs43198 uDAC stereo audio DA converter UAC1 24/96]
 0x1d50 | 0x6156 | [https://github.com/daglem/reDIP-SID reDIP SID (DFU)]
 0x1d50 | 0x6157 | [https://github.com/ddB0515/nRF52840-BBoard nRF52840-BBoard Bootloader]


### PR DESCRIPTION
The EncoderPad RP2040 is a Video Editing Macropad which runs a RP2040 processsor. To able to add this board as a new CircuitPython-supported board, I need a unique PID.  For more information on the project, refer to the [hardware repo](https://github.com/jpconstantineau/EncoderPad_RP2040).

License: CERN Open Hardware Licence Version 2 - Weakly Reciprocal

The following PID will be assigned to this hardware
0x1d50 | 0x616f | [https://github.com/jpconstantineau/EncoderPad_RP2040/ EncoderPad RP2040 Firmware]

At this time, I do not see the need for multiple PIDs assigned to this hardware.

I believe I covered everything from your requirements. Let me know if there is something missing.
