### PR TITLE
added BlueMicro833

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -306,6 +306,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x614f | [https://github.com/Shik-Tech/N32B N32B midi controller]
 0x1d50 | 0x6150 | [https://osmocom.org/projects/e1-t1-adapter/wiki/E1_tracer Osmocom E1 tracer (DFU)]
 0x1d50 | 0x6151 | [https://osmocom.org/projects/e1-t1-adapter/wiki/E1_tracer Osmocom E1 tracer]
+0x1d50 | 0x6152 | [https://github.com/jpconstantineau/BlueMicro833_hardware/ BlueMicro833 Firmware]
 0x1d50 | 0x6153 | [https://github.com/jpconstantineau/PyKey60/ PyKey60 RP2040 Firmware]
 0x1d50 | 0x6154 | [https://github.com/jpconstantineau/EncoderPad_RP2040/ EncoderPad RP2040 Firmware]
 0x1d50 | 0x6155 | [https://bitbucket.org/lukaso25/udac-cs43198 uDAC stereo audio DA converter UAC1 24/96]
@@ -334,6 +335,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x616c | [https://github.com/TheiaSpace/ESATCOM Theia Space's ESAT Ground Station]
 0x1d50 | 0x616d | [https://git.osmocom.org/simtrace2/ sysmoOCTSIMTEST board using SIMtrace2 firmware]
 0x1d50 | 0x616e | [https://git.osmocom.org/simtrace2/ ngff-cardem board using SIMtrace2 firmware]
+0x1d50 | 0x616f | [https://github.com/jpconstantineau/BlueMicro833_hardware/ BlueMicro833 Bootloader]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
Requesting 2 PIDs:

## Bootloader PID

First one is for the bootloader; which is also open sourced [here](https://github.com/adafruit/Adafruit_nRF52_Bootloader) and needs unique PID for any new boards incommpatible with other ones.   The bootloader uses the combination of USB VID and PID when uploading a new UF2 bootloader.[See here](https://github.com/adafruit/Adafruit_nRF52_Bootloader/blob/master/src/boards/pca10100/pinconfig.c)  Since this is intended for nrf52833 boards instead of nrf52840 boards, it is essential to have separate PID allocation so that a nrf52840 bootloader isn't flashed to a nrf552833 module (amount of flash and ram differs).  Additionally, the Arduino IDE uses PID/VID when in bootloader mode for identifying the port to program the board. 
See [here](https://arduino.github.io/arduino-cli/0.19/pluggable-discovery-specification/#board-identification) for more infomation.
This infers that the bootloader PID should be different for Arduino to be able to differentiate between boards.  

[Bootloader License](https://github.com/adafruit/Adafruit_nRF52_Bootloader): MIT License

## Target Hardware

Target hardware is the [BlueMicro833 hardware](https://github.com/jpconstantineau/BlueMicro833_hardware).  This is a breakout board for the nRF52833 chip with the form factor of an Arduuino Pro Micro board. Since this is a generic board which can be used in many applications, the firmware PID request indicated below is for both Arduino support package and CircuitPython support.  All the design and fabrication files are provided as part of the repository and can act as a reference design for other boards to use the samme bootloader PID.

[Hardware License](https://github.com/jpconstantineau/BlueMicro833_hardware): CERN Open Hardware Licence Version 2 - Weakly Reciprocal

## Firmware PID

Second PID is for the firmware;  Both Arduino and CircuitPython will use this PID however, CircuitPython requires unique VID/PID pairs between boards.  The Arduino configuration will use the same PID as for Circuitpython.  

[CircuitPython License](https://github.com/adafruit/circuitpython):  MIT License

[Community_nRF52_Arduino](https://github.com/jpconstantineau/Community_nRF52_Arduino) Board Package License:  Lesser General Public License v2.1
