### PR TITLE
Request PID for Bakeneko Keyboard

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -338,6 +338,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x616f | [https://github.com/jpconstantineau/BlueMicro833_hardware/ BlueMicro833 Bootloader]
 0x1d50 | 0x6170 | [https://github.com/notro/pico-usb-io-board Raspberry Pi Pico USB I/O Board]
 0x1d50 | 0x6171 | [https://github.com/kkatano/bakeneko-60 A simple 60% keyboard]
+0x1d50 | 0x6172 | [https://github.com/kkatano/bakeneko-65 A simple 65% keyboard]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]

--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -337,6 +337,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x616e | [https://git.osmocom.org/simtrace2/ ngff-cardem board using SIMtrace2 firmware]
 0x1d50 | 0x616f | [https://github.com/jpconstantineau/BlueMicro833_hardware/ BlueMicro833 Bootloader]
 0x1d50 | 0x6170 | [https://github.com/notro/pico-usb-io-board Raspberry Pi Pico USB I/O Board]
+0x1d50 | 0x6171 | [https://github.com/kkatano/bakeneko-60 A simple 60% keyboard]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
- Project Name: Bakeneko
- Project Link: https://github.com/kkatano/bakeneko-60 / https://github.com/kkatano/bakeneko-65
- License: MIT License

This is an open source keyboard project that supports 60% and 65% layouts. The works included in this project are the design of the PCB, the case, and the plate to hold the key switch. All of them are released under the MIT license. Using [QMK](https://github.com/qmk/qmk_firmware) for software.