### PR TITLE
Request PID for Yugure Keyboard

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -339,6 +339,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6170 | [https://github.com/notro/pico-usb-io-board Raspberry Pi Pico USB I/O Board]
 0x1d50 | 0x6171 | [https://github.com/kkatano/bakeneko-60 A simple 60% keyboard]
 0x1d50 | 0x6172 | [https://github.com/kkatano/bakeneko-65 A simple 65% keyboard]
+0x1d50 | 0x6173 | [https://github.com/kkatano/yugure Yugure 60% WKL keyboard]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
- Project Name: Yugure
- Project Link: https://github.com/kkatano/yugure
- License: MIT License

This is an open source keyboard project that supports 60% winkey-less layout. The works included in this project are the design of the PCB, the case, and the plate to hold the key switch. All of them are released under the MIT license. Using [QMK](https://github.com/qmk/qmk_firmware) for software.

