### PR TITLE
free-dap

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -340,6 +340,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6171 | [https://github.com/kkatano/bakeneko-60 A simple 60% keyboard]
 0x1d50 | 0x6172 | [https://github.com/kkatano/bakeneko-65 A simple 65% keyboard]
 0x1d50 | 0x6173 | [https://github.com/kkatano/yugure Yugure 60% WKL keyboard]
+0x1d50 | 0x6174 | [https://github.com/ataradov/free-dap/ free-dap cmsis-dap debugger]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
Hi.

I'd like to request an USB Product ID for "free-dap" and its forks.

"free-dap" is an open and free implementation of CMSIS-DAP debugger firmware, both software and hardware.
The original free-dap project for atmel processors: https://github.com/ataradov/free-dap/
My fork for stm32f411 and gd32vf103: https://github.com/koendv/free-dap
License is BSD.

Best wishes for 2022. Thank you for this service.

Koen
