### PR TITLE
Added usb-to-midi

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -341,6 +341,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6172 | [https://github.com/kkatano/bakeneko-65 A simple 65% keyboard]
 0x1d50 | 0x6173 | [https://github.com/kkatano/yugure Yugure 60% WKL keyboard]
 0x1d50 | 0x6175 | [https://github.com/smunaut/ice40-playground/tree/master/projects/usb_amr iCE40 AMR modem interface]
+0x1d50 | 0x6176 | [https://github.com/rafaelmartins/eurorack USB to MIDI Eurorack module]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
Project: usb-to-midi
Source: https://github.com/rafaelmartins/eurorack/tree/main/modules/usb-to-midi
License: https://github.com/rafaelmartins/eurorack/blob/main/LICENSE

This is a monorepo with more projects, build documentation still being written.