### PR TITLE
usb_ids: Requests for IDs for the AMR modem interface using iCE40

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -340,6 +340,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6171 | [https://github.com/kkatano/bakeneko-60 A simple 60% keyboard]
 0x1d50 | 0x6172 | [https://github.com/kkatano/bakeneko-65 A simple 65% keyboard]
 0x1d50 | 0x6173 | [https://github.com/kkatano/yugure Yugure 60% WKL keyboard]
+0x1d50 | 0x6175 | [https://github.com/smunaut/ice40-playground/tree/master/projects/usb_amr iCE40 AMR modem interface]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
The gateware and firmware are in the linked repo and under various
licenses. Generally the gateware modules are under one of the
CERN-OHL-V2 license, and the software under GPL/LGPL/MIT.
Each file has associated SPDX header and full license text for
the various license is in top level doc/.

The associate hardware is also technicaly open hardware but is
not under my control, this targets the icebreaker dev board
manually wired to a AMR slot breakout board, there is no
dedicated hw yet.

At some point it might move repo with dedicated hardware, host
software, ... but for now this is it.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>