### PR TITLE
Request USB ID for CanBoot

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -344,6 +344,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6173 | [https://github.com/kkatano/yugure Yugure 60% WKL keyboard]
 0x1d50 | 0x6175 | [https://github.com/smunaut/ice40-playground/tree/master/projects/usb_amr iCE40 AMR modem interface]
 0x1d50 | 0x6176 | [https://github.com/rafaelmartins/eurorack USB to MIDI Eurorack module]
+0x1d50 | 0x6177 | [https://github.com/Arksine/CanBoot CanBoot Bootloader (CDC ACM)]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
CanBoot is a configurable bootloader for ARM Cortex-M devices.

Licensed under the GNU GPLv3.  The source is available at
https://github.com/Arksine/CanBoot

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>