### PR TITLE
Added pico-synth

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -345,6 +345,8 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6175 | [https://github.com/smunaut/ice40-playground/tree/master/projects/usb_amr iCE40 AMR modem interface]
 0x1d50 | 0x6176 | [https://github.com/rafaelmartins/eurorack USB to MIDI Eurorack module]
 0x1d50 | 0x6177 | [https://github.com/Arksine/CanBoot CanBoot Bootloader (CDC ACM)]
+0x1d50 | 0x6178 | [https://github.com/rafaelmartins/pico-synth pico-synth midi library]
+0x1d50 | 0x6179 | [https://github.com/rafaelmartins/pico-synth pico-synth]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
Project: pico-synth
Source: https://github.com/rafaelmartins/pico-synth
License: https://github.com/rafaelmartins/pico-synth/blob/master/LICENSE

I'm requesting two PIDs, one as default for the midi library, that may be used as building block for other synthesizers, and one for the reference implementation.