### PR TITLE
usb_ids: Requests for IDs for the iCE40 USB Trace

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -350,6 +350,8 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x617a | [https://git.cuvoodoo.info/kingkevin/board/src/branch/usb_hub CuVoodoo USB hub]
 0x1d50 | 0x617b | [https://git.cuvoodoo.info/kingkevin/esp32-s2_dfu CuVoodoo ESP32-S2 USB DFU]
 0x1d50 | 0x617c | [https://github.com/sol/chord-zero CHORD ZERO Stenographic Keyboard]
+0x1d50 | 0x617d | [https://gitea.osmocom.org/electronics/ice40-usbtrace iCE40 USB Trace (DFU)]
+0x1d50 | 0x617e | [https://gitea.osmocom.org/electronics/ice40-usbtrace iCE40 USB Trace]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
The icE40-usbtrace is an Open Source Hardware + Software passive
tracer/sniffer for USB full-speed communication.

hardware license is CC-BY-SA 3.0
gateware license is CERN-OHL-V2 (different variants depending on module)
firmware license is LGPL v3 / GPL v3
software license is LGPL v2.1

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>