### PR TITLE
Request PID for Bloop NFC Scanner

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -352,6 +352,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x617c | [https://github.com/sol/chord-zero CHORD ZERO Stenographic Keyboard]
 0x1d50 | 0x617d | [https://gitea.osmocom.org/electronics/ice40-usbtrace iCE40 USB Trace (DFU)]
 0x1d50 | 0x617e | [https://gitea.osmocom.org/electronics/ice40-usbtrace iCE40 USB Trace]
+0x1d50 | 0x617f | [https://github.com/bloop-box/nfc-scanner-firmware Bloop NFC Scanner]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
This request is for the Bloop NFC UID Scanner, a device to read in NFC UIDs from tags and output them as keyboard events together with specific hotkeys.

The firmware for the project can be found here and is released under BSD-2-Clause license:
https://github.com/bloop-box/nfc-scanner-firmware

Hardware for it can be any RP2040 connected to an MFRC522.