### PR TITLE
Request ID for ctrl-M replacement controller for the IBM Model M 101/102

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -353,6 +353,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x617d | [https://gitea.osmocom.org/electronics/ice40-usbtrace iCE40 USB Trace (DFU)]
 0x1d50 | 0x617e | [https://gitea.osmocom.org/electronics/ice40-usbtrace iCE40 USB Trace]
 0x1d50 | 0x617f | [https://github.com/bloop-box/nfc-scanner-firmware Bloop NFC Scanner]
+0x1d50 | 0x6180 | [https://github.com/nuess0r/ctrl-m ctrl-M replacement controller for the IBM Model M 101/102]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
ctrl-M Controller for Model M keyboards

This is a replacement controller for the famous IBM Model M keyboard based on the STM32F072 microcontroller.

Hardware:
https://github.com/nuess0r/ctrl-M
Released under CERN-OHL-S

Software:
QMK https://github.com/nuess0r/qmk_firmware/tree/ctrl_m/keyboards/ibm/model_m/ctrl_m
Released under GPL 2.0