### PR TITLE
Request PID for brokeIO RP2040

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -354,6 +354,9 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x617e | [https://gitea.osmocom.org/electronics/ice40-usbtrace iCE40 USB Trace]
 0x1d50 | 0x617f | [https://github.com/bloop-box/nfc-scanner-firmware Bloop NFC Scanner]
 0x1d50 | 0x6180 | [https://github.com/nuess0r/ctrl-m ctrl-M replacement controller for the IBM Model M 101/102]
+0x1d50 | 0x6181 | [https://github.com/sugoku/piuio-pico-brokeIO brokeIO RP2040 (Gamepad)]
+0x1d50 | 0x6182 | [https://github.com/sugoku/piuio-pico-brokeIO brokeIO RP2040 (Keyboard)]
+0x1d50 | 0x6183 | [https://github.com/sugoku/piuio-pico-brokeIO brokeIO RP2040 (Other)]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
**Name and Description**: brokeIO, Bedrock's replacement for obsolete Korean hardware I/O.
Replacement I/O solution for arcade dance machines.

**License**: The majority of the software code is under MIT, though some code from the Raspberry Pi repository is under the BSD-3-Clause license. Hardware is not provided but is RP2040-based

**Link**: https://github.com/sugoku/piuio-pico-brokeIO

**Descriptive strings for IDs (in order)**:
- brokeIO RP2040 (Gamepad)
- brokeIO RP2040 (Keyboard)
- brokeIO RP2040 (Other)

I would like to have multiple PIDs as this solution supports acting as multiple HID devices and switching between them.