### PR TITLE
Rename CanBoot to Katapult

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -344,7 +344,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6173 | [https://github.com/kkatano/yugure Yugure 60% WKL keyboard]
 0x1d50 | 0x6175 | [https://github.com/smunaut/ice40-playground/tree/master/projects/usb_amr iCE40 AMR modem interface]
 0x1d50 | 0x6176 | [https://github.com/rafaelmartins/eurorack USB to MIDI Eurorack module]
-0x1d50 | 0x6177 | [https://github.com/Arksine/CanBoot CanBoot Bootloader (CDC ACM)]
+0x1d50 | 0x6177 | [https://github.com/Arksine/katapult Katapult Bootloader (CDC ACM)]
 0x1d50 | 0x6178 | [https://github.com/rafaelmartins/pico-synth pico-synth midi library]
 0x1d50 | 0x6179 | [https://github.com/rafaelmartins/pico-synth pico-synth]
 0x1d50 | 0x617a | [https://git.cuvoodoo.info/kingkevin/board/src/branch/usb_hub CuVoodoo USB hub]


### PR DESCRIPTION
The CanBoot bootloader project has been renamed to [Katapult](https://github.com/Arksine/katapult).  This pull request updates `usb_product_ids.psv` to reflect the change.  Thanks!

Eric