### PR TITLE
request: Add Jumperless to PID list

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -364,3 +364,4 @@ Vendor ID | Product ID | Description
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]
+0x1d50 | 0xACAB | [https://github.com/Architeuthis-Flux/Jumperless Jumperless]

--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -365,3 +365,4 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]
 0x1d50 | 0xACAB | [https://github.com/Architeuthis-Flux/Jumperless Jumperless]
+0x1d50 | 0xACAC | [https://github.com/Architeuthis-Flux/Jumperless Jumperless routable UART]


### PR DESCRIPTION
Jumperless - a jumperless breadboard

Licenses:
Hardware - CERN-OHL-W-2.0
Software - MIT
Documentation - CC-BY-4.0

OSHWA ID: US002417

https://github.com/Architeuthis-Flux/Jumperless

I might need one more PID as the Jumperless shows up as 2 USB endpoints (the other acts as a routable USB-UART bridge), and it might happen that we'll need that to show up as a completely separate device in the future.

I hope it's okay to pick an arbitrary PID to match the current made-up PID I've been using. If not, it's fine and I can make it sequential.

Anyway, thanks for doing this!