### PR TITLE
Mutenix Macroboard

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -362,6 +362,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6186 | [https://github.com/shurik179/yozh Yozh robot]
 0x1d50 | 0x6187 | [https://osmocom.org/projects/baseband/wiki/OsmoGTM900 OsmoGTM900]
 0x1d50 | 0x6188 | [https://github.com/Turm-Design-Works/fub fub MIDI control interface for Foot-SW & Exp-Pedal]
+0x1d50 | 0x6189 | [https://github.com/mutenix-org/firmware-macroboard Mutenix Macroboard for Online Meetings]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
Please accept mu Pull Request for my Mutenix Macroboard.

Its main Focus is to easily mute/unmute during Teams calls, but can be adapted to other useful stuff.

- [Hardware](https://github.com/mutenix-org/hardware-macroboard): CERN Open Hardware Licence Version 2 - Strongly Reciprocal
- [Firmware](https://github.com/mutenix-org/firmware-macroboard): MIT
- [Software Host](https://github.com/mutenix-org/software-host): MIT

Hardware used is either a RPI2040 or NRF52840.
