### PR TITLE
Request PID for Torii ILA USB Backhaul interface

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -363,6 +363,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6187 | [https://osmocom.org/projects/baseband/wiki/OsmoGTM900 OsmoGTM900]
 0x1d50 | 0x6188 | [https://github.com/Turm-Design-Works/fub fub MIDI control interface for Foot-SW & Exp-Pedal]
 0x1d50 | 0x6189 | [https://github.com/mutenix-org/firmware-macroboard Mutenix Macroboard for Online Meetings]
+0x1d50 | 0x6190 | [https://github.com/shrine-maiden-heavy-industries/torii-ila/ Torii HDL Integrated Logic Analyzer (USB Backhaul Interface)]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
Torii ILA is an Integrated Logic Analyzer for Torii HDL based projects. It has several interfaces for data extraction from the device the gateware is running on, including USB.

License: BSD-3-Clause.
Source: https://github.com/shrine-maiden-heavy-industries/torii-ila/
Description: Torii HDL Integrated Logic Analyzer (USB Backhaul Interface)