### PR TITLE
Request PID for Unified Controller Input Spec

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -363,6 +363,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6187 | [https://osmocom.org/projects/baseband/wiki/OsmoGTM900 OsmoGTM900]
 0x1d50 | 0x6188 | [https://github.com/Turm-Design-Works/fub fub MIDI control interface for Foot-SW & Exp-Pedal]
 0x1d50 | 0x6189 | [https://github.com/mutenix-org/firmware-macroboard Mutenix Macroboard for Online Meetings]
+0x1d50 | 0x6191 | [https://github.com/ShadowBlip/UnifiedControllerInputSpec Unified Controller Input Specification]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
I would like to request a PID for the following project:

Project: Unified Controller Input Specification
Source: https://github.com/ShadowBlip/UnifiedControllerInputSpec/
License: [MIT](https://github.com/ShadowBlip/UnifiedControllerInputSpec/blob/main/LICENSE)

This request may be a little different than normal in that the PID would be used by any virtual device (or physical device) that implements the [Unified Controller Input Specification](https://github.com/ShadowBlip/UnifiedControllerInputSpec/), which is an open MIT-licensed specification. The first project implementing the specification is called [InputPlumber](https://github.com/ShadowBlip/InputPlumber/pull/294), which is GPL3 licensed.

Thank you!