### PR TITLE
request pid for picoTracker Advance

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -364,6 +364,8 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6188 | [https://github.com/Turm-Design-Works/fub fub MIDI control interface for Foot-SW & Exp-Pedal]
 0x1d50 | 0x6189 | [https://github.com/mutenix-org/firmware-macroboard Mutenix Macroboard for Online Meetings]
 0x1d50 | 0x6190 | [https://github.com/shrine-maiden-heavy-industries/torii-ila/ Torii HDL Integrated Logic Analyzer (USB Backhaul Interface)]
+0x1d50 | 0x6191 | [https://github.com/xiphonics/picoTracker picoTracker+ bootloader]
+0x1d50 | 0x6192 | [https://github.com/xiphonics/picoTracker picoTracker+]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]

--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -364,8 +364,8 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6188 | [https://github.com/Turm-Design-Works/fub fub MIDI control interface for Foot-SW & Exp-Pedal]
 0x1d50 | 0x6189 | [https://github.com/mutenix-org/firmware-macroboard Mutenix Macroboard for Online Meetings]
 0x1d50 | 0x6190 | [https://github.com/shrine-maiden-heavy-industries/torii-ila/ Torii HDL Integrated Logic Analyzer (USB Backhaul Interface)]
-0x1d50 | 0x6191 | [https://github.com/xiphonics/picoTracker picoTracker+ bootloader]
-0x1d50 | 0x6192 | [https://github.com/xiphonics/picoTracker picoTracker+]
+0x1d50 | 0x6191 | [https://github.com/xiphonics/picoTracker picoTracker Advance bootloader]
+0x1d50 | 0x6192 | [https://github.com/xiphonics/picoTracker picoTracker Advance]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
picoTracker+ is an open source hardware music Tracker. Requesting PID for main firmware and for bootloader (DFU)

Project source: https://github.com/xiphonics/picoTracker
License: BSD-3-Clause (https://github.com/xiphonics/picoTracker?tab=License-1-ov-file)

Requests:
* Firmware: main firmware to support USB MIDI
* Bootloader: Support for DFU programming
