### PR TITLE
Request PIDs for MIDI2USB Converter (MIDI1.0 and MIDI2.0)

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -366,6 +366,8 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6190 | [https://github.com/shrine-maiden-heavy-industries/torii-ila/ Torii HDL Integrated Logic Analyzer (USB Backhaul Interface)]
 0x1d50 | 0x6191 | [https://github.com/xiphonics/picoTracker picoTracker Advance bootloader]
 0x1d50 | 0x6192 | [https://github.com/xiphonics/picoTracker picoTracker Advance]
+0x1d50 | 0x6194 | [https://github.com/collet-instruments/MIDI2USB-Converter MIDI2USB Converter(MIDI1.0)]
+0x1d50 | 0x6195 | [https://github.com/collet-instruments/MIDI2USB-Converter MIDI2USB Converter(MIDI2.0)]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
## USB PID Request for MIDI2USB Converter

**Project Information:**
- Repository: https://github.com/collet-instruments/MIDI2USB-Converter
- License: MIT License
- Description: Open source MIDI to USB converter hardware

**Requested PID Allocation:**
- 0x6194: MIDI2USB Converter(for MIDI1.0)
- 0x6195: MIDI2USB Converter(for MIDI2.0)

**Justification:**
This project provides an open source solution for converting MIDI signals to USB, filling a gap in affordable MIDI conversion tools. The hardware design and firmware are fully open source under MIT license.

The project requires multiple PIDs for different operational modes, following the pattern established by other projects like picoTracker.

Thank you for your consideration.