### PR TITLE
request a PID for smart-card/fido open source firmwares

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -373,6 +373,7 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6198 | [https://github.com/betrusted-io/xous-core/ Baosec security token]
 0x1d50 | 0x6199 | [https://github.com/Jiu-xiao/libxr XRobot USB device stack for Microcontroller]
 0x1d50 | 0x619a | [https://github.com/rafaelmartins/fightstick A customizable fight stick for Linux and MiSTer FPGA]
+0x1d50 | 0x619b | [https://github.com/librekeys/pico-fido2 Generic security key]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
Hello,

I'm writing on behalf of a community of users of the firmwares for security keys developed by picokeys.com
But we are not affiliated with picokeys.com in any way. We are only users of the open source firmwares they have developed.

We have an issue with these firmwares that even if they are open source, cannot be fully used without some proprietary companion application of picokeys.com that is required to commission/configure the devices after having programmed them with a firmware. That proprietary application was before freely usable. So even if it was closed source, as it is needed to be used only once, nobody had enough motivation to develop an open source alternative.

But picokeys.com has recently locked this companion application behind a paywall. They have also stopped licensing one of their firmware under an open source license and have removed its source code from internet. And we fear they might do the same with the other firmwares.


This has impulsed the creation of a community (https://github.com/librekeys is our only presence on internet at the moment) that is working on : 

- developing from scratch an open open source version of the companion application needed to commission/configure the devices

- distribute pre-built binary versions of the firmwares that can be fully used with the open source companion application.

- forking the latest open source version of the firmware that is now closed source and maintaining it.

- for the short term, be prepared to fork and maintain the other firmwares in case picokeys.com stop maintaining them under an open source license.

- for the longer terms, redevelop from scratch all the firmwares because we are not terribly happy with the current code developed by picokeys.com that we find difficult to maintain.


However, for the 2 first steps, we need to have a valid VID and PID that we can set in the firmware source code, include in the pre-built binaries that we are publishing on github and that we could communicate to the developers of the drivers that use VID/PID to recognize smart card devices (namely https://ccid.apdu.fr/)

We are not manufacturing any hardware. The firmwares can be installed on any generic micro-controller board based on raspberry pico RP2350 or espressif ESP32-S3 chips, with one USB port, one button and one LED. But maybe we will develop an open source reference hardware design in the furure.

We don't need a PID that would be reserved for own own use. There is no specific driver developed for these devices. The devices can be used through the standard drivers for smart cards (PCSC) and fido2(webAuthn) devices. This PID could be of use for other similar open source projects that are targeting different hardware platforms.


Would it be possible for openmoko to allocate a PID that could be used by any open source project developing smart card / fido security devices?
