### PR TITLE
Request USB PIDs for PRISM Film Scanner

### DIFF
--- a/usb_product_ids.psv
+++ b/usb_product_ids.psv
@@ -376,6 +376,8 @@ Vendor ID | Product ID | Description
 0x1d50 | 0x6199 | [https://github.com/Jiu-xiao/libxr XRobot USB device stack for Microcontroller]
 0x1d50 | 0x619a | [https://github.com/rafaelmartins/fightstick A customizable fight stick for Linux and MiSTer FPGA]
 0x1d50 | 0x619b | [https://github.com/librekeys/pico-fido2 Generic security key]
+0x1d50 | 0x619c | [https://github.com/mr258876/PRISM-Film-Scanner Project PRISM Film Scanner FIFO Buffer]
+0x1d50 | 0x619d | [https://github.com/mr258876/PRISM-Film-Scanner Project PRISM Film Scanner Control Interface]
 0x1d50 |  | 0x1d50 0x???(0/4/8/c) #########- insert next record here -#########'''   *R!*
 0x1d50 | 0x8085 | [http://madresistor.org/box0/ Box0 (box0-v5) - Free/Open source tool for exploring science and electronics]
 0x1d50 | 0xCC15 | [https://rad1o.badge.events.ccc.de/ rad1o badge for CCC congress 2015]


### PR DESCRIPTION
# USB PID Request for Project PRISM Film Scanner

**Project Information**

Repository: https://github.com/mr258876/PRISM-Film-Scanner
License: MIT License for firmware, CERN-OHL-W for hardware
Description: Open source high-resolution film scanner

**Requested PID Allocation**

- 0x619C: Project PRISM Film Scanner FIFO Buffer

    The buffer device is a CY7C68013A configured in slave mode, conncted directly to 2x8bit DDR ADC data output bus, and hence could only be used for sending ADC data to PC.

- 0x619D: Project PRISM Film Scanner Control Interface

    The control interface device is a RP2040 which controls the CCD sensor, ADCs, and also the 0x619C USB buffer. Control packets needs to go to this device.

Although the project is early stage (only the sensor board itself & software is finished), but the remaining parts are not USB-related, and will not need any more PID, their controls could be done with device 0x619D.

All hardware files, and firmware source for RP2040 are included. The source code of CY7C68013A needs serval Cypress lib files, which I'm not sure they're feasible for uploading, so I just included the files that I wrote, serval patch files for code I modified, and a build guide.

Thanks for your attention!